### PR TITLE
Default to Saved Games directory on first launch

### DIFF
--- a/Source/utils.cpp
+++ b/Source/utils.cpp
@@ -1,6 +1,7 @@
 #include "utils.hpp"
 
 #include <windows.h>
+#include <ShlObj.h>
 #include <intrin.h>
 #include <cassert>
 #include <string>
@@ -161,3 +162,17 @@ std::vector<uintptr_t> sse2_strstr(const unsigned char* s, size_t m, const unsig
   return ret;
 }
 
+
+std::optional<std::filesystem::path> find_user_saved_games() {
+  PWSTR out_ptr{};
+  HRESULT hr = SHGetKnownFolderPath(FOLDERID_SavedGames, KF_FLAG_DEFAULT, nullptr, &out_ptr);
+  if (SUCCEEDED(hr)) {
+    std::shared_ptr<void> free_guard(out_ptr, CoTaskMemFree);
+    auto subdir = std::filesystem::path(out_ptr) / "CD Projekt Red" / "Cyberpunk 2077";
+    std::error_code ec;
+    if (exists(subdir, ec) && !ec && is_directory(subdir, ec) && !ec) {
+      return subdir;
+    }
+  }
+  return {};
+}

--- a/Source/utils.hpp
+++ b/Source/utils.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <filesystem>
+#include <optional>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -286,3 +288,4 @@ std::string bytes_to_hex(const void* buf, size_t len);
 std::vector<uintptr_t> sse2_strstr_masked(const unsigned char* s, size_t m, const unsigned char* needle, size_t n, const char* mask, size_t maxcnt = 0);
 std::vector<uintptr_t> sse2_strstr(const unsigned char* s, size_t m, const unsigned char* needle, size_t n, size_t maxcnt = 0);
 
+std::optional<std::filesystem::path> find_user_saved_games();

--- a/Source/widgets/csav_widget.hpp
+++ b/Source/widgets/csav_widget.hpp
@@ -745,8 +745,20 @@ public:
     try
     {
       auto& jroot = ps_storage::jroot();
-      if (jroot.find("open_path") != jroot.end())
-        open_dialog.SetPwd(jroot.at("open_path").get<std::string>());
+      std::error_code ec;
+      std::optional<std::filesystem::path> pwd;
+      if (jroot.find("open_path") != jroot.end()) {
+        std::filesystem::path dir = jroot.at("open_path").get<std::string>();
+        if (exists(dir, ec) && !ec) {
+            pwd = dir;
+        }
+      }
+      if (auto dir = find_user_saved_games()) {
+        pwd = *dir;
+      }
+      if (pwd) {
+        open_dialog.SetPwd(*pwd);
+      }
     }
     catch (std::exception&) {}
   }


### PR DESCRIPTION
In #8 a way to navigate to the user's Saved Games directory on first launch is desired.
This introduces a utility function to find the directory if it exists and uses it as the default directory for the open dialog unless another one is recorded in persistent storage.